### PR TITLE
Fix Notable Channels for ReactOS Community server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,7 +1073,7 @@ Language: English
 <img align="left" height="94px" width="94px" alt="Server Icon" src="images/server_icons/reactos_community.png" />
 
 [__ReactOS Community__](https://discord.com/invite/7knjvhT) \
-Notable Channels: `#general`, `#support`, `#working-programs`, `#working-programs`, `#working-hardware`, `#debugging`, `#teaching-room`, `#reactos-news` \
+Notable Channels: `#general`, `#support`, `#working-programs`, `#working-hardware`, `#debugging`, `#teaching-room`, `#reactos-youtube`, `#git-highlights` \
 Language: English
 
 <img align="left" height="94px" width="94px" alt="Server Icon" src="images/server_icons/r_chromeos.png" />


### PR DESCRIPTION
- Remove nonexistent `#reactos-news` channel and replace it with existing `#reactos-youtube`
- Remove duplicate of `#working-programs` channel
- Add `#git-highlights` channel which is notable, and to keep the count of notable channels :)