### PR TITLE
Remove wrong repository badge for #include<c++>

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,8 +551,8 @@ Language: English \
 
 <img align="left" height="94px" width="94px" alt="Server Icon" src="images/server_icons/include.webp">
 
-[__#include__](https://discord.gg/ZPErMGW) [<img height="16px" width="16px" alt="Homepage URL" src="images/badges/homepage.webp">](https://www.includecpp.org/) [<img height="16px" width="16px" alt="Git Repository" src="images/badges/git.webp">](https://github.com/mniip/discord-eval) \
-Notable Channels: `#assembly`, `#c`, `#gpu`, `#audio`, `#build-systems`, `#cpp`, `#embedded`, `#learning`, `#security` `#conferences`, `#tooling`, `#2d-graphics`, `#clion`, `#catch2`, `#qt` \
+[__#include__](https://discord.gg/ZPErMGW) [<img height="16px" width="16px" alt="Homepage URL" src="images/badges/homepage.webp">](https://www.includecpp.org/) \
+Notable Channels: `#assembly`, `#c-language`, `#gpu`, `#audio`, `#build-systems`, `#cpp`, `#embedded`, `#learning`, `#security` `#conferences`, `#tooling`, `#2d-graphics`, `#clion`, `#catch2`, `#qt` \
 Language: English
 
 <img align="left" height="94px" width="94px" alt="Server Icon" src="images/server_icons/c_plus_plus_help.webp">

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Language: English \
 
 <img align="left" height="94px" width="94px" alt="Server Icon" src="images/server_icons/include.webp">
 
-[__#include__](https://discord.gg/ZPErMGW) [<img height="16px" width="16px" alt="Homepage URL" src="images/badges/homepage.webp">](https://www.includecpp.org/) \
+[__#include__](https://www.includecpp.org/discord/#getting-started-with-discord) [<img height="16px" width="16px" alt="Homepage URL" src="images/badges/homepage.webp">](https://www.includecpp.org/) \
 Notable Channels: `#assembly`, `#c-language`, `#gpu`, `#audio`, `#build-systems`, `#cpp`, `#embedded`, `#learning`, `#security` `#conferences`, `#tooling`, `#2d-graphics`, `#clion`, `#catch2`, `#qt` \
 Language: English
 


### PR DESCRIPTION
 The badge link for #include was pointing to a wrong repository. Considering we don't really have any public facing repository, I remove the badge altogether. I also edited a channel name that changed since then.

Also, we would ideally like to send people through https://www.includecpp.org/discord/ when they want to join the discord, but I get the main link is supposed to send to the discord server directly, so I didn't touch it.

Have a nice day ^^

