### PR TITLE
Update CS Career Hackers to CS Career Hub and fix deadlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -2056,7 +2056,7 @@ Discussions on interview challenges, resume reviews, job opportunities in the fi
 
 <img align="left" height="94px" width="94px" alt="Server Icon" src="images/server_icons/cs_career_hackers.webp">
 
-[__CS Career Hackers__](https://discord.com/invite/rGwhXJv) [<img height="16px" width="16px" alt="Official Badge" src="images/badges/official.webp">](badges.md#official-identification-badge) [<img height="16px" width="16px" alt="Homepage URL" src="images/badges/homepage.webp">](https://www.cscareerhackers.org/) [<img height="16px" width="16px" alt="Git Repository" src="images/badges/git.webp">](https://github.com/CS-Career-Hackers) \
+[__CS Career Hub__](https://discord.com/invite/ndFR4RF) [<img height="16px" width="16px" alt="Official Badge" src="images/badges/official.webp">](badges.md#official-identification-badge) [<img height="16px" width="16px" alt="Homepage URL" src="images/badges/homepage.webp">](https://cscareerhub.com/) [<img height="16px" width="16px" alt="Git Repository" src="images/badges/git.webp">](https://github.com/cscareerhub) \
 Notable Channels: `#big-n-discussion`, `#experienced`, `#resume-review`, `#career-questions`, `#ask-a-manager`, `#students`, `#meetups`, `#programming-challenges` \
 Language: English
 


### PR DESCRIPTION
I have updated the discord invite link with a newer one and also changed the name, website and GitHub link to CS Career Hub. Fixes #99